### PR TITLE
Add ActiveModel Validation Callbacks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    virtus_model (0.2.7)
+    virtus_model (0.2.8)
       activemodel (~> 4.2)
       activesupport (~> 4.2)
       virtus (~> 1.0)
@@ -50,6 +50,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    shoulda-callback-matchers (1.1.4)
+      activesupport (>= 3)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     simplecov (0.11.2)
@@ -73,9 +75,10 @@ DEPENDENCIES
   rake (~> 11.1)
   rdoc (~> 4.2)
   rspec (~> 3.4)
+  shoulda-callback-matchers (~> 1.1.4)
   shoulda-matchers (~> 3.1)
   simplecov (~> 0.11)
   virtus_model!
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/lib/virtus_model/base.rb
+++ b/lib/virtus_model/base.rb
@@ -6,9 +6,10 @@ module VirtusModel
   class Base
     include ActiveModel::Conversion
     include ActiveModel::Validations
+    include ActiveModel::Validations::Callbacks
     include Virtus.model(nullify_blank: true)
 
-    set_callback :validate, :validate_associations
+    before_validation :validate_associations
 
     # Get an array of attribute names.
     def self.attributes

--- a/lib/virtus_model/version.rb
+++ b/lib/virtus_model/version.rb
@@ -1,3 +1,3 @@
 module VirtusModel
-  VERSION = '0.2.7'.freeze
+  VERSION = '0.2.8'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ Bundler.setup
 
 require 'virtus_model'
 require 'shoulda/matchers'
+require 'shoulda/callback/matchers'
 require 'active_support/core_ext/object/try'
 
 Shoulda::Matchers.configure do |config|

--- a/spec/virtus_model/base_spec.rb
+++ b/spec/virtus_model/base_spec.rb
@@ -8,6 +8,7 @@ describe VirtusModel::Base do
   let(:simple_model_attributes) { { name: 'test' } }
 
   describe SimpleModel, type: :model do
+    it { is_expected.to callback(:validate_associations).before(:validation) }
     it { is_expected.to validate_presence_of(:name) }
   end
 
@@ -27,6 +28,7 @@ describe VirtusModel::Base do
   end
 
   describe ComplexModel, type: :model do
+    it { is_expected.to callback(:validate_associations).before(:validation) }
     it { is_expected.to validate_presence_of(:model) }
     it { is_expected.to validate_presence_of(:models) }
   end
@@ -36,8 +38,19 @@ describe VirtusModel::Base do
   end
 
   describe InheritedModel, type: :model do
+    it { is_expected.to callback(:validate_associations).before(:validation) }
     it { is_expected.to validate_presence_of(:model) }
     it { is_expected.to validate_presence_of(:models) }
+  end
+
+  class CallbackModel < ComplexModel
+    after_validation :child_callback
+  end
+
+  describe CallbackModel, type: :model do
+    before(:example) { allow(subject).to receive(:child_callback) }
+    it { is_expected.to callback(:validate_associations).before(:validation) }
+    it { is_expected.to callback(:child_callback).after(:validation) }
   end
 
   describe '.attribute?' do

--- a/virtus_model.gemspec
+++ b/virtus_model.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rdoc', '~> 4.2'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'shoulda-matchers', '~> 3.1'
+  s.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.4'
   s.add_development_dependency 'simplecov', '~> 0.11'
 end


### PR DESCRIPTION
This enables the use of validation callbacks like `after_validation`. Figured there weren't any tests to add since that code is already heavily tested in its own repo and none of the specs here broke after adding.