### PR TITLE
Explicitly set Github Actions branch name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10]
+        ruby-version: [2.0.0-p648, 2.1.9, 2.2.10, 2.3.8, 2.4.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.0.0-p648, 2.1.x, 2.2.x, 2.3.x, 2.4.x]
+        ruby-version: [2.0.0-p648, 2.1.10, 2.2.10, 2.3.8, 2.4.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version:
-          - '2.0.0-p648'
-          - '2.1.x'
-          - '2.2.x'
-          - '2.3.x'
-          - '2.4.x'
+        ruby-version: [2.0.0-p648, 2.1.x, 2.2.x, 2.3.x, 2.4.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Some Github Actions settings need to be more explicit.