### PR TITLE
Add Rails version upper bound

### DIFF
--- a/virtus_model.gemspec
+++ b/virtus_model.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'virtus', '~> 1.0'
-  s.add_dependency 'activemodel', '>= 4.2'
-  s.add_dependency 'activesupport', '>= 4.2'
+  s.add_dependency 'activemodel', '>= 4.2', '< 6'
+  s.add_dependency 'activesupport', '>= 4.2', '< 6'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rdoc', '~> 4.2'
   s.add_development_dependency 'rspec', '~> 3.10'


### PR DESCRIPTION
Rails 6 requires us to upgrade the minimum Ruby version, we'll do that separately.